### PR TITLE
test: add basic test setup to reproduce current tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,35 @@
+FROM fluxrm/flux-sched:bookworm
+
+LABEL maintainer="Vanessasaurus <@vsoch>"
+
+# Match the default user id for a single system so we aren't root
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+ENV USERNAME=${USERNAME}
+ENV USER_UID=${USER_UID}
+ENV USER_GID=${USER_GID}
+USER root
+RUN apt-get update && apt-get install -y less
+
+# Install Go 19 (we should update this)
+RUN wget https://go.dev/dl/go1.19.10.linux-amd64.tar.gz  && tar -xvf go1.19.10.linux-amd64.tar.gz && \
+         mv go /usr/local && rm go1.19.10.linux-amd64.tar.gz
+ENV PATH=$PATH:/usr/local/go/bin:/home/vscode/go/bin
+
+RUN git clone https://github.com/flux-framework/flux-sched /opt/flux-sched && \
+    cd /opt/flux-sched && \
+    git fetch && \
+    export FLUX_SCHED_VERSION=0.58.0 && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr && \
+    make && make install
+
+# Add the group and user that match our ids
+RUN groupadd -g ${USER_GID} ${USERNAME} && \
+    adduser --disabled-password --uid ${USER_UID} --gid ${USER_GID} --gecos "" ${USERNAME} && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
+
+USER $USERNAME
+# Assuming installing to /usr/local
+ENV LD_LIBRARY_PATH=/usr/lib:/usr/lib/flux:/usr/local/lib

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "Fluxion Go",
+  "dockerFile": "Dockerfile",
+  "context": "../",
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+  },
+      "extensions": [
+        "ms-vscode.cmake-tools",
+        "golang.go"
+      ]
+    }
+  },
+  "postStartCommand": "git config --global --add safe.directory /workspaces/fluxion-go"
+}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,47 @@
+name: test fluxion-go
+
+# This will be expanded for more robust testing
+# right now we build and run the main test command
+# and test the package "types" directory
+
+on:
+  pull_request: []
+
+jobs:
+  test:
+    name: Test fluxion-go
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [["fluxrm/flux-sched:bookworm", "0.32.0"]]
+
+    container:
+      image: ${{ matrix.test[0] }}
+      options: --user root
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ^1.19
+    # TODO: do we want this to be for different versions? Need to coincide with container bases
+    # We also want the reapi_cli.so to be built by default
+    - name: flux-sched build
+      env: 
+        version: ${{ matrix.test[1] }}
+      run: |
+       git clone https://github.com/flux-framework/flux-sched /opt/flux-sched
+       export FLUX_SCHED_VERSION=${version}
+       cd /opt/flux-sched
+       ./autogen.sh
+       ./configure --prefix=/usr
+       make && make install  
+       ls /usr/lib/flux
+    
+    - name: Build
+      run: make build
+    - name: Test Binary
+      run: make test-binary
+    - name: Test Modules
+      run: make test-modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+bin

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+HERE ?= $(shell pwd)
+LOCALBIN ?= $(shell pwd)/bin
+JGF ?= $(HERE)/cmd/test/data/tiny.json
+JOBSPECS ?= $(HERE)/cmd/test/data/jobspecs
+
+# This assumes a build in the .devcontainer Dockerfile environment
+FLUX_SCHED_ROOT ?= /opt/flux-sched
+INSTALL_PREFIX ?= /usr
+COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z)
+LD_LIBRARY_PATH=/usr/lib:/usr/lib/flux:/usr/local/lib:/usr/local/lib/flux
+
+BUILDENVVAR=CGO_CFLAGS="-I${FLUX_SCHED_ROOT} -I${FLUX_SCHED_ROOT}/resource/reapi/bindings/c" CGO_LDFLAGS="-L${INSTALL_PREFIX}/lib -L${INSTALL_PREFIX}/lib/flux -L${FLUX_SCHED_ROOT}/resource/reapi/bindings -lreapi_cli -lflux-idset -lstdc++ -lczmq -ljansson -lhwloc -lboost_system -lflux-hostlist -lboost_graph -lyaml-cpp"
+# BUILDENVAR=CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS='${CGO_LIBRARY_FLAGS}' go build -ldflags '-w'
+
+
+.PHONY: all
+all: build
+
+.PHONY: test
+test: test-binary test-modules
+
+.PHONY: test-modules
+test-modules: 
+	go test -v ./pkg/types
+
+.PHONY: test-binary
+test-binary: 	
+	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) $(LOCALBIN)/test --jgf=$(JGF) --jobspec=$(JOBSPECS)/test001.yaml
+
+# test001_desc="match allocate 1 slot: 1 socket: 1 core (pol=default)"
+# test_expect_success "${test001_desc}" '
+#    ${main} --jgf=${jgf} --jobspec=${jobspec1} > 001.R.out &&
+#    sed -i -E "s/, 0\.[0-9]+//g" 001.R.out &&
+#    test_cmp 001.R.out ${exp_dir}/001.R.out
+#'
+
+#test002_desc="match allocate 2 slots: 2 sockets: 5 cores 1 gpu 6 memory"
+#test_expect_success "${test002_desc}" '
+#    ${main} --jgf=${jgf} --jobspec=${jobspec2} > 002.R.out &&
+#    sed -i -E "s/, 0\.[0-9]+//g" 002.R.out &&
+#    test_cmp 002.R.out ${exp_dir}/002.R.out
+#'
+
+.PHONY: $(LOCALBIN)
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+# This serves as a single test file to build a dummy main to test
+.PHONY: build $(LOCALBIN)
+build: 
+	mkdir -p $(LOCALBIN)
+	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-w' -o $(LOCALBIN)/test cmd/test/test.go
+
+.PHONY: clean
+clean:
+	rm -rf $(LOCALBIN)/test

--- a/NOTICE.LLNS
+++ b/NOTICE.LLNS
@@ -1,0 +1,21 @@
+This work was produced under the auspices of the U.S. Department of
+Energy by Lawrence Livermore National Laboratory under Contract
+DE-AC52-07NA27344.
+
+This work was prepared as an account of work sponsored by an agency of
+the United States Government. Neither the United States Government nor
+Lawrence Livermore National Security, LLC, nor any of their employees
+makes any warranty, expressed or implied, or assumes any legal liability
+or responsibility for the accuracy, completeness, or usefulness of any
+information, apparatus, product, or process disclosed, or represents that
+its use would not infringe privately owned rights.
+
+Reference herein to any specific commercial product, process, or service
+by trade name, trademark, manufacturer, or otherwise does not necessarily
+constitute or imply its endorsement, recommendation, or favoring by the
+United States Government or Lawrence Livermore National Security, LLC.
+
+The views and opinions of authors expressed herein do not necessarily
+state or reflect those of the United States Government or Lawrence
+Livermore National Security, LLC, and shall not be used for advertising
+or product endorsement purposes.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,39 @@
 
 Fluxion Go are the Go bindings for the flux scheduler [flux-framework.org/flux-sched](https://github.com/flux-framework.org/flux-sched) that we call "fluxion." You can read more about the project there. In short, you might want to use these bindings if you're interested in integrating the flux scheduler logic (graph-based, hierarchical scheduling) into your Go applications.
 
+## Usage
+
+Currently, you can build in the [Development Container](.devcontainer) in VSCode and then flux-sched will be installed to `/usr` and header files (.h) available at `/opt/flux-sched`. You can build the test suite as follows:
+
+```bash
+make
+```
+```console
+mkdir -p /workspaces/fluxion-go/bin
+GOOS=linux CGO_CFLAGS="-I/opt/flux-sched -I/opt/flux-sched/resource/reapi/bindings/c" CGO_LDFLAGS="-L/usr/lib -L/usr/lib/flux -L/opt/flux-sched/resource/reapi/bindings -lreapi_cli -lflux-idset -lstdc++ -lczmq -ljansson -lhwloc -lboost_system -lflux-hostlist -lboost_graph -lyaml-cpp" go build -ldflags '-w' -o /workspaces/fluxion-go/bin/test cmd/test/test.go
+```
+
+If you need to customize the flux install prefix or the location (root) of the flux-sched repository (with header files):
+
+```bash
+FLUX_SCHED_ROOT=/home/path/flux-sched INSTALL_PREFIX=/usr/local make
+```
+
+Here is how to run tests:
+
+```bash
+# run all tests
+make test
+
+# run binary test (e.g., build main and run)
+make test-binary
+
+# run go native tests
+make test-modules
+```
+
+More work and updates will be coming soon.
+
 #### License
 
 SPDX-License-Identifier: LGPL-3.0

--- a/cmd/test/data/jobspecs/test001.yaml
+++ b/cmd/test/data/jobspecs/test001.yaml
@@ -1,0 +1,30 @@
+version: 9999
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 1
+              with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: socket
+                        count: 1
+                        with:
+                          - type: core
+                            count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1
+

--- a/cmd/test/data/tiny.json
+++ b/cmd/test/data/tiny.json
@@ -1,0 +1,3490 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "basename": "tiny",
+          "name": "tiny0",
+          "id": 0,
+          "uniq_id": 0,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0"
+          }
+        }
+      },
+      {
+        "id": "1",
+        "metadata": {
+          "type": "rack",
+          "basename": "rack",
+          "name": "rack0",
+          "id": 0,
+          "uniq_id": 1,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0"
+          }
+        }
+      },
+      {
+        "id": "2",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node0",
+          "id": 0,
+          "uniq_id": 2,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0"
+          }
+        }
+      },
+      {
+        "id": "3",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node1",
+          "id": 1,
+          "uniq_id": 3,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1"
+          }
+        }
+      },
+      {
+        "id": "4",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 4,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0"
+          }
+        }
+      },
+      {
+        "id": "5",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 5,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1"
+          }
+        }
+      },
+      {
+        "id": "6",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 6,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0"
+          }
+        }
+      },
+      {
+        "id": "7",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 7,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1"
+          }
+        }
+      },
+      {
+        "id": "8",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 0,
+          "uniq_id": 8,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "9",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 9,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "10",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 10,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "11",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 11,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "12",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 12,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "13",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 13,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "14",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 14,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "15",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 15,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "16",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 16,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "17",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 17,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "18",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 18,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "19",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 19,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "20",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 20,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "21",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 21,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "22",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 22,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "23",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 23,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "24",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 24,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "25",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 25,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "26",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 26,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "27",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 27,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "28",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 28,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "29",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 29,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "30",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 30,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "31",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 31,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "32",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 32,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "33",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 33,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "34",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 34,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "35",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 35,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "36",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 36,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "37",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 37,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "38",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 38,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "39",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 39,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "40",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 40,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "41",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 41,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "42",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 42,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "43",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 43,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "44",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 0,
+          "uniq_id": 44,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "45",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 45,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "46",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 46,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "47",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 47,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "48",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 48,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "49",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 49,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "50",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 50,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "51",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 51,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "52",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 52,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "53",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 53,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "54",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 54,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "55",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 55,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "56",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 56,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "57",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 57,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "58",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 58,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "59",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 59,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "60",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 60,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "61",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 61,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "62",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 62,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "63",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 63,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "64",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 64,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "65",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 65,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "66",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 66,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "67",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 67,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "68",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 68,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "69",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 69,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "70",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 70,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "71",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 71,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "72",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 72,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "73",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 73,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "74",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 74,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "75",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 75,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "76",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 76,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "77",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 77,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "78",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 78,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "79",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 79,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "80",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 80,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "81",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 81,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "82",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 82,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "83",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 83,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "84",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory0",
+          "id": 0,
+          "uniq_id": 84,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/memory0"
+          }
+        }
+      },
+      {
+        "id": "85",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory1",
+          "id": 1,
+          "uniq_id": 85,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/memory1"
+          }
+        }
+      },
+      {
+        "id": "86",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory2",
+          "id": 2,
+          "uniq_id": 86,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/memory2"
+          }
+        }
+      },
+      {
+        "id": "87",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory3",
+          "id": 3,
+          "uniq_id": 87,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket0/memory3"
+          }
+        }
+      },
+      {
+        "id": "88",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory4",
+          "id": 4,
+          "uniq_id": 88,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/memory4"
+          }
+        }
+      },
+      {
+        "id": "89",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory5",
+          "id": 5,
+          "uniq_id": 89,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/memory5"
+          }
+        }
+      },
+      {
+        "id": "90",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory6",
+          "id": 6,
+          "uniq_id": 90,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/memory6"
+          }
+        }
+      },
+      {
+        "id": "91",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory7",
+          "id": 7,
+          "uniq_id": 91,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node0/socket1/memory7"
+          }
+        }
+      },
+      {
+        "id": "92",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory0",
+          "id": 0,
+          "uniq_id": 92,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/memory0"
+          }
+        }
+      },
+      {
+        "id": "93",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory1",
+          "id": 1,
+          "uniq_id": 93,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/memory1"
+          }
+        }
+      },
+      {
+        "id": "94",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory2",
+          "id": 2,
+          "uniq_id": 94,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/memory2"
+          }
+        }
+      },
+      {
+        "id": "95",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory3",
+          "id": 3,
+          "uniq_id": 95,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket0/memory3"
+          }
+        }
+      },
+      {
+        "id": "96",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory4",
+          "id": 4,
+          "uniq_id": 96,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/memory4"
+          }
+        }
+      },
+      {
+        "id": "97",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory5",
+          "id": 5,
+          "uniq_id": 97,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/memory5"
+          }
+        }
+      },
+      {
+        "id": "98",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory6",
+          "id": 6,
+          "uniq_id": 98,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/memory6"
+          }
+        }
+      },
+      {
+        "id": "99",
+        "metadata": {
+          "type": "memory",
+          "basename": "memory",
+          "name": "memory7",
+          "id": 7,
+          "uniq_id": 99,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "GB",
+          "size": 2,
+          "paths": {
+            "containment": "/tiny0/rack0/node1/socket1/memory7"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "0",
+        "target": "1",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "0",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "2",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "3",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "2",
+        "target": "1",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "2",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "2",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "3",
+        "target": "1",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "3",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "3",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "2",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "8",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "9",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "10",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "11",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "12",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "13",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "14",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "15",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "16",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "17",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "18",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "19",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "20",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "21",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "22",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "23",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "24",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "25",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "80",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "84",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "85",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "86",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "87",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "2",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "26",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "27",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "28",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "29",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "30",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "31",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "32",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "33",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "34",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "35",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "36",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "37",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "38",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "39",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "40",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "41",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "42",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "43",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "81",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "88",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "89",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "90",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "91",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "3",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "44",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "45",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "46",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "47",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "48",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "49",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "50",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "51",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "52",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "53",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "54",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "55",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "56",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "57",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "58",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "59",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "60",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "61",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "82",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "92",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "93",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "94",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "95",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "3",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "62",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "63",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "64",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "65",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "66",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "67",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "68",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "69",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "70",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "71",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "72",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "73",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "74",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "75",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "76",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "77",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "78",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "79",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "83",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "96",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "97",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "98",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "99",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "14",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "15",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "16",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "17",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "18",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "19",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "20",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "21",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "22",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "23",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "24",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "25",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "26",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "27",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "28",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "29",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "30",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "31",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "32",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "33",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "34",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "35",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "36",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "37",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "38",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "39",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "40",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "41",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "42",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "43",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "44",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "45",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "46",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "47",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "48",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "49",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "50",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "51",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "52",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "53",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "54",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "55",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "56",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "57",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "58",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "59",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "60",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "61",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "62",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "63",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "64",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "65",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "66",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "67",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "68",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "69",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "70",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "71",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "72",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "73",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "74",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "75",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "76",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "77",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "78",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "79",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "80",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "81",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "82",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "83",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "84",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "85",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "86",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "87",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "88",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "89",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "90",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "91",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "92",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "93",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "94",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "95",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "96",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "97",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "98",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      },
+      {
+        "source": "99",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "in"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -15,8 +15,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/flux-framework/flux-sched/resource/reapi/bindings/go/src/fluxcli"
-	"github.com/flux-framework/flux-sched/resource/reapi/bindings/go/src/pkg/types"
+	"github.com/flux-framework/fluxion-go/pkg/fluxcli"
+	"github.com/flux-framework/fluxion-go/pkg/types"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/flux-framework/fluxion-go
+
+go 1.19

--- a/pkg/fluxcli/reapi_cli.go
+++ b/pkg/fluxcli/reapi_cli.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"unsafe"
 
-	"github.com/flux-framework/flux-sched/resource/reapi/bindings/go/src/pkg/types"
+	"github.com/flux-framework/fluxion-go/pkg/types"
 )
 
 type (

--- a/pkg/fluxmodule/reapi_module.go
+++ b/pkg/fluxmodule/reapi_module.go
@@ -15,8 +15,7 @@ import "C"
 import (
 	"fmt"
 	"unsafe"
-
-	"github.com/flux-framework/flux-sched/resource/reapi/bindings/go/src/pkg/types"
+	"github.com/flux-framework/fluxion-go/pkg/types"
 )
 
 type (


### PR DESCRIPTION
Problem: we need to reproduce tests currently in flux-sched here. Solution: separate the tests (modules and binary) in a Makefile, also adding support for make build to build the binary (and assert that the fluxmodule and fluxcli are functioning as expected).