### PR TITLE
test: adding testing matrix for os release matrix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxrm/flux-sched:bookworm
+FROM fluxrm/flux-sched:bookworm-amd64
 
 LABEL maintainer="Vanessasaurus <@vsoch>"
 
@@ -17,13 +17,7 @@ RUN wget https://go.dev/dl/go1.19.10.linux-amd64.tar.gz  && tar -xvf go1.19.10.l
          mv go /usr/local && rm go1.19.10.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin:/home/vscode/go/bin
 
-RUN git clone https://github.com/flux-framework/flux-sched /opt/flux-sched && \
-    cd /opt/flux-sched && \
-    git fetch && \
-    export FLUX_SCHED_VERSION=0.58.0 && \
-    ./autogen.sh && \
-    ./configure --prefix=/usr && \
-    make && make install
+RUN git clone https://github.com/flux-framework/flux-sched /opt/flux-sched
 
 # Add the group and user that match our ids
 RUN groupadd -g ${USER_GID} ${USERNAME} && \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,12 @@ name: test fluxion-go
 
 on:
   pull_request: []
+  workflow_dispatch:
+
+  # Bindings should always be checked against the latest containers
+  # 2:10 every Thursday
+  schedule:
+    - cron:  '10 2 * * 4'  
 
 jobs:
   test:
@@ -14,7 +20,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [["fluxrm/flux-sched:bookworm", "0.32.0"]]
+        # container base and lib prefix
+        test: [["fluxrm/flux-sched:jammy", "/usr/lib"],
+               ["fluxrm/flux-sched:fedora38", "/usr/lib64"],
+               ["fluxrm/flux-sched:bookworm-amd64", "/usr/lib"],
+               ["fluxrm/flux-sched:el8", "/usr/lib64"]]
 
     container:
       image: ${{ matrix.test[0] }}
@@ -25,23 +35,13 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ^1.19
-    # TODO: do we want this to be for different versions? Need to coincide with container bases
-    # We also want the reapi_cli.so to be built by default
+
+    # TODO: we should consider distributing the header files with the release builds
     - name: flux-sched build
-      env: 
-        version: ${{ matrix.test[1] }}
-      run: |
-       git clone https://github.com/flux-framework/flux-sched /opt/flux-sched
-       export FLUX_SCHED_VERSION=${version}
-       cd /opt/flux-sched
-       ./autogen.sh
-       ./configure --prefix=/usr
-       make && make install  
-       ls /usr/lib/flux
-    
+      run: git clone https://github.com/flux-framework/flux-sched /opt/flux-sched    
     - name: Build
-      run: make build
+      run: LIB_PREFIX=${{ matrix.test[1] }} make build
     - name: Test Binary
-      run: make test-binary
+      run: LIB_PREFIX=${{ matrix.test[1] }} make test-binary
     - name: Test Modules
       run: make test-modules

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,15 @@ JOBSPECS ?= $(HERE)/cmd/test/data/jobspecs
 # This assumes a build in the .devcontainer Dockerfile environment
 FLUX_SCHED_ROOT ?= /opt/flux-sched
 INSTALL_PREFIX ?= /usr
+
+# Needed to distinguish /usr/lib and /usr/lib54
+LIB_PREFIX ?= /usr/lib
 COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z)
-LD_LIBRARY_PATH=/usr/lib:/usr/lib/flux:/usr/local/lib:/usr/local/lib/flux
 
-BUILDENVVAR=CGO_CFLAGS="-I${FLUX_SCHED_ROOT} -I${FLUX_SCHED_ROOT}/resource/reapi/bindings/c" CGO_LDFLAGS="-L${INSTALL_PREFIX}/lib -L${INSTALL_PREFIX}/lib/flux -L${FLUX_SCHED_ROOT}/resource/reapi/bindings -lreapi_cli -lflux-idset -lstdc++ -lczmq -ljansson -lhwloc -lboost_system -lflux-hostlist -lboost_graph -lyaml-cpp"
-# BUILDENVAR=CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS='${CGO_LIBRARY_FLAGS}' go build -ldflags '-w'
+# Note that el8 and derivatives are in /usr/lib64
+LD_LIBRARY_PATH=$(LIB_PREFIX):$(LIB_PREFIX)/flux
 
+BUILDENVVAR=CGO_CFLAGS="-I${FLUX_SCHED_ROOT} -I${FLUX_SCHED_ROOT}/resource/reapi/bindings/c" CGO_LDFLAGS="-L${LIB_PREFIX} -L${LIB_PREFIX}/flux -L${FLUX_SCHED_ROOT}/resource/reapi/bindings -lreapi_cli -lflux-idset -lstdc++ -lczmq -ljansson -lhwloc -lboost_system -lflux-hostlist -lboost_graph -lyaml-cpp"
 
 .PHONY: all
 all: build


### PR DESCRIPTION
Problem: we want to make sure that fluxion-go builds across OS releases. Solution: add each major build to the testing matrix. In addition, we want to use bookworm-amd64 over bookworm, which does not appear to be updated. With these newer containers we do not need to build flux-sched to create the bindings (reapi_cli.so) as they are already installed to /usr