### PR TITLE
ci: add docker build environment and deploy

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -1,0 +1,44 @@
+name: build docker fluxion-go
+
+on:
+  pull_request: []
+  release:
+    types: [published]
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: make and build docker containers
+    env:
+      container: ghcr.io/flux-framework/fluxion-go
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ^1.19
+    - name: GHCR Login
+      if: (github.event_name != 'pull_request')
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build Container
+      run: docker build -t ${{ env.container }} .
+
+    - name: Tag Release Image
+      if: (github.event_name == 'release')
+      run: |
+        tag=${GITHUB_REF#refs/tags/}
+        echo "Tagging and releasing ${{ env.container}}:${tag}"        
+        docker tag ${{ env.container }}:latest ${{ env.container }}:${tag}
+
+    - name: Deploy Container
+      if: (github.event_name != 'pull_request')
+      run: docker push ${{ env.container }} --all-tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM fluxrm/flux-sched:bookworm-amd64
+
+# Basic container to provide quick developer environment with everything ready to go
+
+LABEL maintainer="Vanessasaurus <@vsoch>"
+
+USER root
+RUN apt-get update && apt-get install -y less
+
+# Install Go 19 (we should update this)
+RUN wget https://go.dev/dl/go1.19.10.linux-amd64.tar.gz  && tar -xvf go1.19.10.linux-amd64.tar.gz && \
+         mv go /usr/local && rm go1.19.10.linux-amd64.tar.gz
+ENV PATH=$PATH:/usr/local/go/bin:/home/vscode/go/bin
+
+RUN git clone https://github.com/flux-framework/flux-sched /opt/flux-sched
+
+# Assuming installing to /usr/local
+ENV LD_LIBRARY_PATH=/usr/lib:/usr/lib/flux:/usr/local/lib
+WORKDIR /workspace/fluxion-go
+COPY . .

--- a/README.md
+++ b/README.md
@@ -35,7 +35,25 @@ make test-binary
 make test-modules
 ```
 
-More work and updates will be coming soon.
+## Docker 
+
+In addition to the developer environment, we provide an automated build with the [Dockerfile](Dockerfile) here
+that will give you a containerized environment with Go, the bindings, and flux-sched. You can pull the repository
+from our package registry, or build on your own:
+
+```bash
+docker build -t ghcr.io/flux-framework/fluxion-go .
+docker run -it ghcr.io/flux-framework/fluxion-go
+```
+
+Then you can build, and test.
+
+```bash
+make
+make test
+```
+
+Have fun! 🧞‍♀️️
 
 #### License
 


### PR DESCRIPTION
Problem: a developer may want an environment with everything ready to go 
Solution: provide a Dockerfile to build, akin to the VSCode environment, but not requiring VSCode. Have it push to an automated release so it is always available.