### PR TITLE
go: update to 1.21

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,12 +9,14 @@ ARG USER_GID=1000
 ENV USERNAME=${USERNAME}
 ENV USER_UID=${USER_UID}
 ENV USER_GID=${USER_GID}
+ENV GO_VERSION=1.21.9
+
 USER root
 RUN apt-get update && apt-get install -y less
 
-# Install Go 19 (we should update this)
-RUN wget https://go.dev/dl/go1.19.10.linux-amd64.tar.gz  && tar -xvf go1.19.10.linux-amd64.tar.gz && \
-         mv go /usr/local && rm go1.19.10.linux-amd64.tar.gz
+# Install Go
+RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz  && tar -xvf go${GO_VERSION}.linux-amd64.tar.gz && \
+         mv go /usr/local && rm go${GO_VERSION}.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin:/home/vscode/go/bin
 
 RUN git clone https://github.com/flux-framework/flux-sched /opt/flux-sched

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: ^1.19
+        go-version: ^1.21
     - name: GHCR Login
       if: (github.event_name != 'pull_request')
       uses: docker/login-action@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v4
       with:
-        go-version: ^1.19
+        go-version: ^1.21
 
     # TODO: we should consider distributing the header files with the release builds
     - name: flux-sched build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v4
       with:
-        go-version: ^1.19
+        go-version: ^1.21
 
     - name: flux-sched build
       run: git clone https://github.com/flux-framework/flux-sched /opt/flux-sched    

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,14 @@ FROM fluxrm/flux-sched:bookworm-amd64
 # Basic container to provide quick developer environment with everything ready to go
 
 LABEL maintainer="Vanessasaurus <@vsoch>"
+ENV GO_VERSION=1.21.9
 
 USER root
 RUN apt-get update && apt-get install -y less
 
-# Install Go 19 (we should update this)
-RUN wget https://go.dev/dl/go1.19.10.linux-amd64.tar.gz  && tar -xvf go1.19.10.linux-amd64.tar.gz && \
-         mv go /usr/local && rm go1.19.10.linux-amd64.tar.gz
+# Install Go
+RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz  && tar -xvf go${GO_VERSION}.linux-amd64.tar.gz && \
+         mv go /usr/local && rm go${GO_VERSION}.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin:/home/vscode/go/bin
 
 RUN git clone https://github.com/flux-framework/flux-sched /opt/flux-sched

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Fluxion Go
 
-> 🚧️ This is a work in progress and should not be used yet! 🚧️
-
-Fluxion Go are the Go bindings for the flux scheduler [flux-framework.org/flux-sched](https://github.com/flux-framework.org/flux-sched) that we call "fluxion." You can read more about the project there. In short, you might want to use these bindings if you're interested in integrating the flux scheduler logic (graph-based, hierarchical scheduling) into your Go applications.
+Fluxion Go provides the Go bindings for the flux scheduler [flux-framework.org/flux-sched](https://github.com/flux-framework.org/flux-sched) that we call "fluxion." You can read more about the project there. In short, you might want to use these bindings if you're interested in integrating the flux scheduler logic (graph-based, hierarchical scheduling) into your Go applications.
 
 ## Usage
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/flux-framework/fluxion-go
 
-go 1.19
+go 1.21


### PR DESCRIPTION
Problem: Fluence (that uses these bindings) is stuck on 1.21, which will prevent integration with the rainbow scheduler and other Kubernetes projects, which tend to be on 1.21 or 1.22
Solution: update Fluence to 1.21