### PR TITLE
build: remove boost_system from dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z)
 # Note that el8 and derivatives are in /usr/lib64
 LD_LIBRARY_PATH=$(LIB_PREFIX):$(LIB_PREFIX)/flux
 
-BUILDENVVAR=CGO_CFLAGS="-I${FLUX_SCHED_ROOT} -I${FLUX_SCHED_ROOT}/resource/reapi/bindings/c" CGO_LDFLAGS="-L${LIB_PREFIX} -L${LIB_PREFIX}/flux -L${FLUX_SCHED_ROOT}/resource/reapi/bindings -lreapi_cli -lflux-idset -lstdc++ -ljansson -lhwloc -lboost_system -lflux-hostlist -lboost_graph -lyaml-cpp"
+BUILDENVVAR=CGO_CFLAGS="-I${FLUX_SCHED_ROOT} -I${FLUX_SCHED_ROOT}/resource/reapi/bindings/c" CGO_LDFLAGS="-L${LIB_PREFIX} -L${LIB_PREFIX}/flux -L${FLUX_SCHED_ROOT}/resource/reapi/bindings -lreapi_cli -lflux-idset -lstdc++ -ljansson -lhwloc -lflux-hostlist -lboost_graph -lyaml-cpp"
 
 .PHONY: all
 all: build

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ make
 ```
 ```console
 mkdir -p /workspaces/fluxion-go/bin
-GOOS=linux CGO_CFLAGS="-I/opt/flux-sched -I/opt/flux-sched/resource/reapi/bindings/c" CGO_LDFLAGS="-L/usr/lib -L/usr/lib/flux -L/opt/flux-sched/resource/reapi/bindings -lreapi_cli -lflux-idset -lstdc++ -lczmq -ljansson -lhwloc -lboost_system -lflux-hostlist -lboost_graph -lyaml-cpp" go build -ldflags '-w' -o /workspaces/fluxion-go/bin/test cmd/test/test.go
+GOOS=linux CGO_CFLAGS="-I/opt/flux-sched -I/opt/flux-sched/resource/reapi/bindings/c" CGO_LDFLAGS="-L/usr/lib -L/usr/lib/flux -L/opt/flux-sched/resource/reapi/bindings -lreapi_cli -lflux-idset -lstdc++ -lczmq -ljansson -lhwloc -lflux-hostlist -lboost_graph -lyaml-cpp" go build -ldflags '-w' -o /workspaces/fluxion-go/bin/test cmd/test/test.go
 ```
 
 If you need to customize the flux install prefix or the location (root) of the flux-sched repository (with header files):


### PR DESCRIPTION
Problem: the build is failing because the base containers cannot provide lboost_system. I am assuming this was removed as a dependency and thus also from the base containers. 
Solution: remove from the Makefile.