### PR TITLE
feat: shrink support for fluxion

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz  && tar -xvf go${G
 ENV PATH=$PATH:/usr/local/go/bin:/home/vscode/go/bin
 
 # Testing grow/shrink from custom branch
-RUN git clone -b debug-resource-error-messages https://github.com/researchapps/flux-sched /opt/flux-sched
+RUN git clone -b add-shrink https://github.com/researchapps/flux-sched /opt/flux-sched
 # RUN git clone https://github.com/flux-framework/flux-sched /opt/flux-sched
 
 # We also need to rebuild into the system install

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,10 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         # container base and lib prefix
-        test: [["fluxrm/flux-sched:jammy", "/usr/lib"],
+        test: [["fluxrm/flux-sched:noble", "/usr/lib"],
                ["fluxrm/flux-sched:fedora38", "/usr/lib64"],
-               ["fluxrm/flux-sched:bookworm-amd64", "/usr/lib"],
-               ["fluxrm/flux-sched:el8", "/usr/lib64"]]
+               ["fluxrm/flux-sched:bookworm-amd64", "/usr/lib"]] 
 
     container:
       image: ${{ matrix.test[0] }}
@@ -38,7 +37,15 @@ jobs:
 
     # TODO: we should consider distributing the header files with the release builds
     - name: flux-sched build
-      run: git clone https://github.com/flux-framework/flux-sched /opt/flux-sched    
+      run: git clone -b add-shrink https://github.com/researchapps/flux-sched /opt/flux-sched    
+    - name: flux-sched compile
+      run: |
+        export FLUX_SCHED_VERSION=0.39.0
+        cd /opt/flux-sched
+        cmake -B build
+        make -C build
+        make -C build install
+        cd -
     - name: Build
       run: LIB_PREFIX=${{ matrix.test[1] }} make build
     - name: Test Binary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,10 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [["fluxrm/flux-sched:jammy", "/usr/lib"],
+        test: [["fluxrm/flux-sched:noble", "/usr/lib"],
                ["fluxrm/flux-sched:fedora38", "/usr/lib64"],
-               ["fluxrm/flux-sched:bookworm-amd64", "/usr/lib"],
-               ["fluxrm/flux-sched:el8", "/usr/lib64"]]
+               ["fluxrm/flux-sched:bookworm-amd64", "/usr/lib"]]
 
     container:
       image: ${{ matrix.test[0] }}
@@ -33,7 +32,16 @@ jobs:
         go-version: ^1.21
 
     - name: flux-sched build
-      run: git clone https://github.com/flux-framework/flux-sched /opt/flux-sched    
+      run: git clone -b add-shrink https://github.com/researchapps/flux-sched /opt/flux-sched    
+    - name: flux-sched compile
+      run: |
+        export FLUX_SCHED_VERSION=0.39.0
+        cd /opt/flux-sched
+        cmake -B build
+        make -C build
+        make -C build install
+        cd -
+
     - name: Build
       run: LIB_PREFIX=${{ matrix.test[1] }} make build
     - name: Test

--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -173,6 +173,25 @@ func main() {
 		log.Fatalf("Error in ReapiClient MatchSatisfy - asking for 4 nodes should now succeed: %v\n", err)
 	}
 
+	// Shrink (remove subgraph) for node2
+	fmt.Println("🥕 Asking to Shrink from 4 to 3 Nodes")
+	err = cli.Shrink("/tiny0/rack0/node2")
+	if err != nil {
+		log.Fatalf("Error in ReapiClient Shrink: %s %s\n", err, cli.GetErrMsg())
+	}
+	fmt.Printf("Shrink request return value: %v\n", err)
+
+	fmt.Println("Asking to MatchSatisfy 4 nodes (again, not possible)")
+	sat, overhead, err = cli.MatchSatisfy(growJobspec)
+	checkErrors(cli)
+	if err != nil {
+		log.Fatalf("Error in ReapiClient MatchSatisfy: %v\n", err)
+	}
+	printSatOutput(sat, err)
+	if sat {
+		log.Fatalf("Error in ReapiClient MatchSatisfy - asking for 4 nodes with only 3 should fail: %v\n", err)
+	}
+
 }
 
 func printOutput(reserved bool, allocated string, at int64, jobid uint64, err error) {


### PR DESCRIPTION
This changeset exposes the remove_subgraph function, which we can call a shrink. It does not account for (I do not think) handling job cleanup properly, but should be a reasonable start to testing or debugging.